### PR TITLE
more replacements mainly because multiway join can use many input steps

### DIFF
--- a/src/main/java/com/datamelt/hop/uit/ImportTool.java
+++ b/src/main/java/com/datamelt/hop/uit/ImportTool.java
@@ -75,7 +75,7 @@ import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
  */
 public class ImportTool 
 {
-	private static final String version 					= "0.1.8";
+	private static final String version 					= "0.1.9";
 	private static final String versionDate 				= "2020-10-04";
 	
 	private static String inputfolder;
@@ -408,7 +408,8 @@ public class ImportTool
 	 */
 	private static void help()
 	{
-		System.out.println("ImportTool " + getVersionInfo()); 
+		System.out.println("ImportTool " + getVersionInfo());
+		System.out.println();
 		System.out.println("Program to convert files created by the Pentaho Data Integration tool (PDI) into the HOP format.");
 		System.out.println("Files are read from the input folder, converted and output to the output folder. If a file name is");
 		System.out.println("specified, this file is processed from the input folder. Multiple file names may be specified by");
@@ -433,9 +434,8 @@ public class ImportTool
     	System.out.println("       : ImportTool -i=/home/me/input -o=/home/me/output -f=myfile.ktr");
     	System.out.println("       : ImportTool -i=/home/me/input -o=/home/me/output -f=myfile1.ktr -f=myfile2.ktr -f=myfile3.kjb");
     	System.out.println();
-    	System.out.println("published as open source under the Apache License. read the licence notice.");
-    	System.out.println("check https://github.com/uwegeercken for more");
-    	System.out.println("all code by uwe geercken, 2020. uwe.geercken@web.de");
+    	System.out.println("published as open source under the Apache License. read the licence notice. check https://github.com/uwegeercken for more");
+    	System.out.println("created by uwe geercken, 2020. uwe.geercken@web.de");
     	System.out.println();
 	}
 	

--- a/src/main/java/com/datamelt/hop/utils/PdiConstants.java
+++ b/src/main/java/com/datamelt/hop/utils/PdiConstants.java
@@ -33,7 +33,12 @@ public class PdiConstants
 	public static final String HOP_WORKFLOW_TAG_ACTION = "action";
 	
 	/**
-	 * returns a map of replacements between the Kettle/PDI format of a transformation and the Hop format of a pipeline 
+	 * returns a map of replacements between the Kettle/PDI format of a transformation and the Hop format of a pipeline
+	 * 
+	 *  some steps reference other steps. especially the multimerge join allows for any number of input steps. I have no
+	 *  way to do the node matching using a regular expression. so I hardcoded step0 to step5 here. If anybody tries to
+	 *  convert one with more input steps then it will break the step and one has to either extend the range here or
+	 *  remove the step from the canvas and re-create it.
 	 * 
 	 * @return	map of tag names and their replacements
 	 */
@@ -43,6 +48,12 @@ public class PdiConstants
 	    replacements.put("transformation", "pipeline");
 	    replacements.put("trans_type", "pipeline_type");
 	    replacements.put("trans_status", "pipeline_status");
+	    replacements.put("step0", "transform0");
+	    replacements.put("step1", "transform1");
+	    replacements.put("step2", "transform2");
+	    replacements.put("step3", "transform3");
+	    replacements.put("step4", "transform4");
+	    replacements.put("step5", "transform5");
 	    replacements.put("step", "transform");
 	    replacements.put("step_error_handling", "transform_error_handling");
 	    replacements.put("job", "workflow");


### PR DESCRIPTION
up the 6 input steps to any step (like the multiway join step) are possible. I have no funtionality to do this using a regex. but this should typically be enough.

Note that Hop v0.30 (master) does NOT have the multiway join step. But v0.40 DOES have this multiway join step.